### PR TITLE
8 restrict content pro failed payment issues

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -252,6 +252,39 @@ class Extension extends AbstractPluginIntegration {
 	}
 
 	/**
+	 * Get account page URL.
+	 * 
+	 * @return string|null
+	 */
+	private function get_account_page_url() {
+		global $rcp_options;
+
+		$url = null;
+
+		if ( ! \is_array( $rcp_options ) ) {
+			return $url;
+		}
+
+		if ( ! \array_key_exists( 'account_page', $rcp_options ) ) {
+			return $url;
+		}
+
+		$page_id = (int) $rcp_options['account_page'];
+
+		if ( 0 === $page_id ) {
+			return $url;
+		}
+
+		$permalink = \get_permalink( $page_id );
+
+		if ( false === $permalink ) {
+			return $url;
+		}
+
+		return $permalink;
+	}
+
+	/**
 	 * Payment redirect URL filter.
 	 *
 	 * @param string  $url     URL.
@@ -265,6 +298,12 @@ class Extension extends AbstractPluginIntegration {
 		}
 
 		if ( Core_PaymentStatus::SUCCESS !== $payment->get_status() ) {
+			$account_page_url = $this->get_account_page_url();
+
+			if ( null !== $account_page_url ) {
+				$url = $account_page_url;
+			}
+
 			return $url;
 		}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -253,7 +253,7 @@ class Extension extends AbstractPluginIntegration {
 
 	/**
 	 * Get account page URL.
-	 * 
+	 *
 	 * @return string|null
 	 */
 	private function get_account_page_url() {
@@ -354,7 +354,12 @@ class Extension extends AbstractPluginIntegration {
 			case Core_PaymentStatus::CANCELLED:
 			case Core_PaymentStatus::EXPIRED:
 			case Core_PaymentStatus::FAILURE:
-				$rcp_payments->update( $rcp_payment_id, $rcp_payment_data );
+				$this_pronamic_payment_id = (string) $payment->get_id();
+				$last_pronamic_payment_id = (string) \rcp_get_payment_meta( $rcp_payment_id, '_pronamic_payment_id', true );
+
+				if ( empty( $last_pronamic_payment_id ) || $this_pronamic_payment_id === $last_pronamic_payment_id ) {
+					$rcp_payments->update( $rcp_payment_id, $rcp_payment_data );
+				}
 
 				$rcp_membership = \rcp_get_membership( $rcp_payment->membership_id );
 
@@ -366,7 +371,6 @@ class Extension extends AbstractPluginIntegration {
 					return;
 				}
 
-				$this_pronamic_payment_id = (string) $payment->get_id();
 				$last_pronamic_payment_id = (string) \rcp_get_membership_meta( $rcp_membership->get_id(), '_pronamic_payment_id', true );
 
 				if ( ! empty( $last_pronamic_payment_id ) && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
@@ -856,6 +860,13 @@ class Extension extends AbstractPluginIntegration {
 		 * payment.
 		 */
 		if ( 'rcp_payment' !== $payment->source ) {
+			return;
+		}
+
+		$this_pronamic_payment_id = (string) $payment->get_id();
+		$last_pronamic_payment_id = (string) \rcp_get_payment_meta( $payment->get_source_id(), '_pronamic_payment_id', true );
+
+		if ( ! empty( $last_pronamic_payment_id ) && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
 			return;
 		}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -357,7 +357,7 @@ class Extension extends AbstractPluginIntegration {
 				$this_pronamic_payment_id = (string) $payment->get_id();
 				$last_pronamic_payment_id = (string) \rcp_get_payment_meta( $rcp_payment_id, '_pronamic_payment_id', true );
 
-				if ( empty( $last_pronamic_payment_id ) || $this_pronamic_payment_id === $last_pronamic_payment_id ) {
+				if ( '' === $last_pronamic_payment_id || $this_pronamic_payment_id === $last_pronamic_payment_id ) {
 					$rcp_payments->update( $rcp_payment_id, $rcp_payment_data );
 				}
 
@@ -373,7 +373,7 @@ class Extension extends AbstractPluginIntegration {
 
 				$last_pronamic_payment_id = (string) \rcp_get_membership_meta( $rcp_membership->get_id(), '_pronamic_payment_id', true );
 
-				if ( ! empty( $last_pronamic_payment_id ) && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
+				if ( '' !== $last_pronamic_payment_id && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
 					return;
 				}
 
@@ -866,7 +866,7 @@ class Extension extends AbstractPluginIntegration {
 		$this_pronamic_payment_id = (string) $payment->get_id();
 		$last_pronamic_payment_id = (string) \rcp_get_payment_meta( $payment->get_source_id(), '_pronamic_payment_id', true );
 
-		if ( ! empty( $last_pronamic_payment_id ) && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
+		if ( '' !== $last_pronamic_payment_id && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
 			return;
 		}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -779,8 +779,7 @@ class Extension extends AbstractPluginIntegration {
 				'customer_id'      => $rcp_membership->get_customer_id(),
 				'membership_id'    => $rcp_membership->get_id(),
 				'amount'           => $payment->get_total_amount()->get_value(),
-				// Transaction ID can not be null therefore we use `strval` to cast `null` to an empty string.
-				'transaction_id'   => \strval( $payment->get_transaction_id() ),
+				'transaction_id'   => '',
 				'subscription'     => \rcp_get_subscription_name( $rcp_membership->get_object_id() ),
 				'subscription_key' => $rcp_membership->get_subscription_key(),
 				'object_type'      => 'subscription',
@@ -853,7 +852,7 @@ class Extension extends AbstractPluginIntegration {
 			$payment->source_id,
 			[
 				'status'         => PaymentStatus::from_core( $payment->get_status() ),
-				'transaction_id' => \strval( $payment->get_transaction_id() ),
+				'transaction_id' => ( Core_PaymentStatus::SUCCESS === $payment->get_status() ) ? (string) $payment->get_transaction_id() : '',
 			]
 		);
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -369,7 +369,7 @@ class Extension extends AbstractPluginIntegration {
 				$this_pronamic_payment_id = (string) $payment->get_id();
 				$last_pronamic_payment_id = (string) \rcp_get_membership_meta( $rcp_membership->get_id(), '_pronamic_payment_id', true );
 
-				if ( $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
+				if ( ! empty( $last_pronamic_payment_id ) && $this_pronamic_payment_id !== $last_pronamic_payment_id ) {
 					return;
 				}
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -836,6 +836,11 @@ class Extension extends AbstractPluginIntegration {
 			);
 		}
 
+		$rcp_payment_id = $result;
+
+		Util::connect_pronamic_payment_id_to_rcp_membership( $rcp_membership->get_id(), $payment );
+		Util::connect_pronamic_payment_id_to_rcp_payment( $rcp_payment_id, $payment );
+
 		// Renew membership.
 		$expiration = '';
 
@@ -856,8 +861,6 @@ class Extension extends AbstractPluginIntegration {
 		$rcp_membership->renew( true, 'active', $expiration );
 
 		// Set source.
-		$rcp_payment_id = $result;
-
 		$payment->source    = 'rcp_payment';
 		$payment->source_id = $rcp_payment_id;
 

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -285,18 +285,6 @@ class Gateway extends RCP_Payment_Gateway {
 			);
 		}
 
-		// Transaction ID.
-		$transaction_id = $payment->get_transaction_id();
-
-		if ( null !== $transaction_id ) {
-			$rcp_payments_db->update(
-				$this->payment->id,
-				[
-					'transaction_id' => $transaction_id,
-				]
-			);
-		}
-
 		$gateway->redirect( $payment );
 
 		exit;

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -269,6 +269,9 @@ class Gateway extends RCP_Payment_Gateway {
 
 		try {
 			$payment = Plugin::start_payment( $payment, $gateway );
+
+			Util::connect_pronamic_payment_id_to_rcp_membership( $this->membership->get_id(), $payment );
+			Util::connect_pronamic_payment_id_to_rcp_payment( $this->payment->id, $payment );
 		} catch ( \Exception $e ) {
 			do_action( 'rcp_registration_failed', $this );
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -290,7 +290,7 @@ class Util {
 	 * @link https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/issues/8
 	 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/blob/8d32295882ac2c4b0c3d3adc6c8355eb13916edb/src/Gateway.php#L446C29-L446C80
 	 * @param int     $rcp_membership_id Restrict Content Pro membership ID.
-	 * @param Payment $paymaent          Pronamic payment object.
+	 * @param Payment $payment           Pronamic payment object.
 	 * @return void
 	 */
 	public static function connect_pronamic_payment_id_to_rcp_payment( $rcp_membership_id, Payment $payment ) {
@@ -303,7 +303,7 @@ class Util {
 	 * @link https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/issues/8
 	 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/blob/8d32295882ac2c4b0c3d3adc6c8355eb13916edb/src/Gateway.php#L446C29-L446C80
 	 * @param int     $rcp_payment_id Restrict Content Pro payment ID.
-	 * @param Payment $paymaent       Pronamic payment object.
+	 * @param Payment $payment        Pronamic payment object.
 	 * @return void
 	 */
 	public static function connect_pronamic_payment_id_to_rcp_membership( $rcp_payment_id, Payment $payment ) {

--- a/src/Util.php
+++ b/src/Util.php
@@ -283,4 +283,30 @@ class Util {
 
 		return $subscription;
 	}
+
+	/**
+	 * Store payment ID in Restrict Content Pro membership meta.
+	 * 
+	 * @link https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/issues/8
+	 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/blob/8d32295882ac2c4b0c3d3adc6c8355eb13916edb/src/Gateway.php#L446C29-L446C80
+	 * @param int     $rcp_membership_id Restrict Content Pro membership ID.
+	 * @param Payment $paymaent          Pronamic payment object.
+	 * @return void
+	 */
+	public static function connect_pronamic_payment_id_to_rcp_payment( $rcp_membership_id, Payment $payment ) {
+		\rcp_update_membership_meta( $rcp_membership_id, '_pronamic_payment_id', (string) $payment->get_id() );
+	}
+
+	/**
+	 * Store payment ID in Restrict Content Pro payment meta.
+	 * 
+	 * @link https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/issues/8
+	 * @link https://github.com/pronamic/wp-pronamic-pay-woocommerce/blob/8d32295882ac2c4b0c3d3adc6c8355eb13916edb/src/Gateway.php#L446C29-L446C80
+	 * @param int     $rcp_payment_id Restrict Content Pro payment ID.
+	 * @param Payment $paymaent       Pronamic payment object.
+	 * @return void
+	 */
+	public static function connect_pronamic_payment_id_to_rcp_membership( $rcp_payment_id, Payment $payment ) {
+		\rcp_update_payment_meta( $rcp_payment_id, '_pronamic_payment_id', (string) $payment->get_id() );
+	}
 }

--- a/views/edit-payment.php
+++ b/views/edit-payment.php
@@ -35,7 +35,7 @@ $pronamic_payment_id = (string) \rcp_get_payment_meta( $payment->id, '_pronamic_
 			</thead>
 
 			<tbody>
-		
+
 				<?php if ( $query->have_posts() ) : ?>
 
 					<?php while ( $query->have_posts() ) : ?>
@@ -57,7 +57,7 @@ $pronamic_payment_id = (string) \rcp_get_payment_meta( $payment->id, '_pronamic_
 							<td>
 								<?php
 
-								if ( $pronamic_payment_id === (string) \get_the_ID() ) {
+								if ( (string) \get_the_ID() === $pronamic_payment_id ) {
 									echo '✓';
 								}
 
@@ -74,7 +74,7 @@ $pronamic_payment_id = (string) \rcp_get_payment_meta( $payment->id, '_pronamic_
 							<?php esc_html_e( 'No payments found.', 'pronamic_ideal' ); ?>
 						</td>
 					</tr>
-				
+
 				<?php endif; ?>
 
 			</tbody>

--- a/views/edit-payment.php
+++ b/views/edit-payment.php
@@ -10,26 +10,74 @@
  * @link https://gitlab.com/pronamic-plugins/restrict-content-pro/blob/3.0.10/includes/admin/payments/edit-payment.php#L127
  */
 
+$pronamic_payment_id = (string) \rcp_get_payment_meta( $payment->id, '_pronamic_payment_id', true );
+
 ?>
+<style type="text/css">
+	.pronamic-pay-payments-table th {
+		line-height: 1.4em;
+
+		padding: 8px 10px;
+	}
+</style>
+
 <tr>
 	<th scope="row" class="row-title">
-		<?php esc_html_e( 'Pronamic Pay Payment', 'pronamic_ideal' ); ?>
+		<?php esc_html_e( 'Pronamic Pay Payments', 'pronamic_ideal' ); ?>
 	</th>
 	<td>
-		<?php
+		<table class="pronamic-pay-payments-table wp-list-table widefat striped table-view-list">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'ID', 'pronamic_ideal' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Last', 'pronamic_ideal' ); ?></th>
+				</tr>
+			</thead>
 
-		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
+			<tbody>
+		
+				<?php if ( $query->have_posts() ) : ?>
 
-				printf(
-					'<a href="%s">%s</a>',
-					esc_url( get_edit_post_link() ),
-					esc_html( get_the_ID() )
-				);
-			}
-		}
+					<?php while ( $query->have_posts() ) : ?>
 
-		?>
+						<tr>
+							<?php $query->the_post(); ?>
+
+							<td>
+								<?php
+
+								printf(
+									'<a href="%s">%s</a>',
+									esc_url( get_edit_post_link() ),
+									esc_html( get_the_ID() )
+								);
+
+								?>
+							</td>
+							<td>
+								<?php
+
+								if ( $pronamic_payment_id === (string) \get_the_ID() ) {
+									echo '✓';
+								}
+
+								?>
+							</td>
+						</tr>
+
+					<?php endwhile; ?>
+
+				<?php else : ?>
+
+					<tr>
+						<td colspan="2">
+							<?php esc_html_e( 'No payments found.', 'pronamic_ideal' ); ?>
+						</td>
+					</tr>
+				
+				<?php endif; ?>
+
+			</tbody>
+		</table>
 	</td>
 </tr>


### PR DESCRIPTION
PR for:

> We can’t change how Restrict Content Pro works, but we can probably do the following:
> 
> 1. No longer expire the RCP membership in the event of a failed payment.
> 2. Only save the transaction ID in the RCP payment if it was successful, so the “Retry Payment” feature is available when payment failed.
> 3. In the event of a failed payment, forward the customer/visitor to the RCP account page where the “Retry Payment” link is visible.
> 
> We don’t have many other options, could this be an improvement that you can work with? Otherwise we have to ask the Restrict Content Pro developers for advice. Or maybe you have ideas of your own to make this even easier?

https://wordpress.org/support/topic/rcp-failed-payment-issues/#post-17016396
