### PR TITLE
17 add feature to update a pronamic pay subscription from a restrict content membership

### DIFF
--- a/pronamic-pay-restrict-content.php
+++ b/pronamic-pay-restrict-content.php
@@ -46,6 +46,15 @@ require_once __DIR__ . '/vendor/autoload_packages.php';
 );
 
 add_filter(
+	'pronamic_pay_modules',
+	function ( $modules ) {
+		$modules[] = 'subscriptions';
+
+		return $modules;
+	}
+);
+
+add_filter(
 	'pronamic_pay_plugin_integrations',
 	function ( $integrations ) {
 		$integrations[] = new \Pronamic\WordPress\Pay\Extensions\RestrictContent\Extension();

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -1065,7 +1065,7 @@ class Extension extends AbstractPluginIntegration {
 			return;
 		}
 
-		$subscription = \get_pronamic_subscription( $subscription_id );
+		$subscription = \get_pronamic_subscription( (int) $subscription_id );
 
 		if ( null === $subscription ) {
 			return;
@@ -1079,7 +1079,7 @@ class Extension extends AbstractPluginIntegration {
 
 		$source_id = $subscription->get_source_id();
 
-		$rcp_membership = \rcp_get_membership( $source_id );
+		$rcp_membership = \rcp_get_membership( (int) $source_id );
 
 		if ( false === $rcp_membership ) {
 			return;

--- a/src/Gateways/Gateway.php
+++ b/src/Gateways/Gateway.php
@@ -53,6 +53,14 @@ class Gateway extends RCP_Payment_Gateway {
 			if ( null !== $payment_method && $payment_method->supports( 'recurring' ) ) {
 				$this->supports = [
 					'recurring',
+					/**
+					 * Renewal date changes.
+					 * 
+					 * @link https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/issues/17
+					 * @link https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/pull/18#issuecomment-2107023059
+					 * @link https://plugins.trac.wordpress.org/browser/restrict-content/tags/3.2.10/core/includes/memberships/class-rcp-membership.php#L3454
+					 */
+					'renewal-date-changes',
 					'trial',
 				];
 			}

--- a/src/SubscriptionUpdater.php
+++ b/src/SubscriptionUpdater.php
@@ -108,8 +108,14 @@ class SubscriptionUpdater {
 		$pronamic_subscription->add_phase( $initial_phase );
 		$pronamic_subscription->add_phase( $regular_phase );
 
-		$next_payment_date = new DateTimeImmutable( $rcp_membership->get_expiration_date( false ) );
-		$next_payment_date = $next_payment_date->setTime( 0, 0, 0 );
+		$next_payment_date = null;
+		
+		$expiration_timestamp = $rcp_membership->get_expiration_time();
+
+		if ( false !== $expiration_timestamp ) {
+			$next_payment_date = new DateTimeImmutable( '@' . $expiration_timestamp );
+			$next_payment_date = $next_payment_date->setTime( 0, 0, 0 );
+		}
 
 		$pronamic_subscription->set_next_payment_date( $next_payment_date );
 	}

--- a/src/SubscriptionUpdater.php
+++ b/src/SubscriptionUpdater.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Subscription updater
+ *
+ * @author    Pronamic <info@pronamic.eu>
+ * @copyright 2005-2023 Pronamic
+ * @license   GPL-3.0-or-later
+ * @package   Pronamic\WordPress\Pay\Extensions\RestrictContent
+ */
+
+namespace Pronamic\WordPress\Pay\Extensions\RestrictContent;
+
+use Pronamic\WordPress\Money\Money;
+use Pronamic\WordPress\Pay\Extensions\RestrictContent\LengthUnit;
+use Pronamic\WordPress\Pay\Subscriptions\Subscription;
+use Pronamic\WordPress\Pay\Subscriptions\SubscriptionInterval;
+use Pronamic\WordPress\Pay\Subscriptions\SubscriptionPhase;
+use RCP_Membership;
+
+/**
+ * Subscription updater class
+ */
+class SubscriptionUpdater {
+	/**
+	 * Restrict Content membership.
+	 *
+	 * @var RCP_Membership
+	 */
+	private $rcp_membership;
+
+	/**
+	 * Pronamic subscription.
+	 *
+	 * @var Subscription
+	 */
+	private $pronamic_subscription;
+
+	/**
+	 * Construct subscription updater.
+	 *
+	 * @param RCP_Membership $rcp_membership        Restrict Content membership.
+	 * @param Subscription   $pronamic_subscription Pronamic subscription.
+	 */
+	public function __construct( RCP_Membership $rcp_membership, Subscription $pronamic_subscription ) {
+		$this->rcp_membership        = $rcp_membership;
+		$this->pronamic_subscription = $pronamic_subscription;
+	}
+
+	/**
+	 * Update Pronamic subscription.
+	 *
+	 * @return void
+	 * @throws \Exception Throws an exception if no Restrict Content membership level can be found.
+	 */
+	public function update_pronamic_subscription() {
+		$rcp_membership        = $this->rcp_membership;
+		$pronamic_subscription = $this->pronamic_subscription;
+
+		$rcp_membership_level = \rcp_get_membership_level( $rcp_membership->get_object_id() );
+
+		if ( false === $rcp_membership_level ) {
+			throw new \Exception( 'Cannot find the Restrict Content membership level for the Restrict Content membership to be updated.' );
+		}
+
+		/**
+		 * Maximum number of times to renew this membership. Default is `0` for unlimited.
+		 *
+		 * @link https://gitlab.com/pronamic-plugins/restrict-content-pro/-/blob/3.3.3/includes/memberships/class-rcp-membership.php#L138-143
+		 * @link https://gitlab.com/pronamic-plugins/restrict-content-pro/-/blob/3.3.3/includes/memberships/class-rcp-membership.php#L1169-1178
+		 */
+		$maximum_renewals = (int) $rcp_membership->get_maximum_renewals();
+
+		$interval_spec = 'P' . $rcp_membership_level->get_duration() . LengthUnit::to_core( $rcp_membership_level->get_duration_unit() );
+	
+		if ( $rcp_membership_level->has_trial() ) {
+			$interval_spec = 'P' . $rcp_membership_level->get_trial_duration() . LengthUnit::to_core( $rcp_membership_level->get_trial_duration_unit() );
+		}
+	
+		$initial_phase = new SubscriptionPhase(
+			$pronamic_subscription,
+			new \DateTimeImmutable( $rcp_membership->get_created_date( false ) ),
+			new SubscriptionInterval( $interval_spec ),
+			new Money( $rcp_membership->get_initial_amount(), $rcp_membership->get_currency() )
+		);
+	
+		$initial_phase->set_total_periods( 1 );
+	
+		$regular_phase = new SubscriptionPhase(
+			$pronamic_subscription,
+			$initial_phase->get_end_date(),
+			new SubscriptionInterval( 'P' . $rcp_membership_level->get_duration() . LengthUnit::to_core( $rcp_membership_level->get_duration_unit() ) ),
+			new Money( $rcp_membership->get_recurring_amount(), $rcp_membership->get_currency() )
+		);
+	
+		if ( 0 !== $maximum_renewals ) {
+			$regular_phase->set_total_periods( $maximum_renewals );
+		}
+
+		$pronamic_subscription->set_phases( [] );
+	
+		$pronamic_subscription->add_phase( $initial_phase );
+		$pronamic_subscription->add_phase( $regular_phase );
+	}
+}

--- a/src/SubscriptionUpdater.php
+++ b/src/SubscriptionUpdater.php
@@ -56,7 +56,7 @@ class SubscriptionUpdater {
 		$rcp_membership        = $this->rcp_membership;
 		$pronamic_subscription = $this->pronamic_subscription;
 
-		$rcp_membership_level = \rcp_get_membership_level( $rcp_membership->get_object_id() );
+		$rcp_membership_level = \rcp_get_membership_level( (int) $rcp_membership->get_object_id() );
 
 		if ( false === $rcp_membership_level ) {
 			throw new \Exception( 'Cannot find the Restrict Content membership level for the Restrict Content membership to be updated.' );
@@ -84,10 +84,16 @@ class SubscriptionUpdater {
 		);
 	
 		$initial_phase->set_total_periods( 1 );
+
+		$initial_phase_end_date = $initial_phase->get_end_date();
+
+		if ( null === $initial_phase_end_date ) {
+			throw new \Exception( 'The initial subscription phase has no end date, this should not happen.' );
+		}
 	
 		$regular_phase = new SubscriptionPhase(
 			$pronamic_subscription,
-			$initial_phase->get_end_date(),
+			$initial_phase_end_date,
 			new SubscriptionInterval( 'P' . $rcp_membership_level->get_duration() . LengthUnit::to_core( $rcp_membership_level->get_duration_unit() ) ),
 			new Money( $rcp_membership->get_recurring_amount(), $rcp_membership->get_currency() )
 		);

--- a/src/SubscriptionUpdater.php
+++ b/src/SubscriptionUpdater.php
@@ -10,6 +10,7 @@
 
 namespace Pronamic\WordPress\Pay\Extensions\RestrictContent;
 
+use DateTimeImmutable;
 use Pronamic\WordPress\Money\Money;
 use Pronamic\WordPress\Pay\Extensions\RestrictContent\LengthUnit;
 use Pronamic\WordPress\Pay\Subscriptions\Subscription;
@@ -78,7 +79,7 @@ class SubscriptionUpdater {
 	
 		$initial_phase = new SubscriptionPhase(
 			$pronamic_subscription,
-			new \DateTimeImmutable( $rcp_membership->get_created_date( false ) ),
+			new DateTimeImmutable( $rcp_membership->get_created_date( false ) ),
 			new SubscriptionInterval( $interval_spec ),
 			new Money( $rcp_membership->get_initial_amount(), $rcp_membership->get_currency() )
 		);
@@ -106,5 +107,10 @@ class SubscriptionUpdater {
 	
 		$pronamic_subscription->add_phase( $initial_phase );
 		$pronamic_subscription->add_phase( $regular_phase );
+
+		$next_payment_date = new DateTimeImmutable( $rcp_membership->get_expiration_date( false ) );
+		$next_payment_date = $next_payment_date->setTime( 0, 0, 0 );
+
+		$pronamic_subscription->set_next_payment_date( $next_payment_date );
 	}
 }

--- a/views/edit-membership.php
+++ b/views/edit-membership.php
@@ -22,11 +22,33 @@
 			while ( $query->have_posts() ) {
 				$query->the_post();
 
+				echo '<div style="display: flex; gap: 1em; align-items: center;">';
+
 				printf(
 					'<a href="%s">%s</a>',
 					esc_url( get_edit_post_link() ),
 					esc_html( get_the_ID() )
 				);
+
+				echo ' ';
+
+				$action_url = wp_nonce_url(
+					add_query_arg(
+						[
+							'subscription_id' => get_the_ID(),
+							'action'          => 'pronamic_pay_rcp_update_subscription',
+						],
+					),
+					'pronamic_pay_rcp_update_subscription_' . get_the_ID()
+				);
+
+				printf(
+					'<a class="button" href="%s">%s</a>',
+					esc_url( $action_url ),
+					'Bijwerken'
+				);
+
+				echo '</div>';
 			}
 		}
 

--- a/views/edit-membership.php
+++ b/views/edit-membership.php
@@ -45,7 +45,14 @@
 				printf(
 					'<a class="button" href="%s">%s</a>',
 					esc_url( $action_url ),
-					'Bijwerken'
+					esc_html__( 'Update details to Pronamic Pay subscription', 'pronamic_ideal' )
+				);
+
+				echo  ' ';
+
+				printf(
+					'<span class="rcp-help-tip dashicons dashicons-editor-help" title="%s"></span>',
+					esc_attr__( 'Updating ensures that date changes in the Restrict Content membership are updated in the Pronamic Pay subscription.', 'pronamic_ideal' )
 				);
 
 				echo '</div>';

--- a/views/edit-membership.php
+++ b/views/edit-membership.php
@@ -48,7 +48,7 @@
 					esc_html__( 'Update details to Pronamic Pay subscription', 'pronamic_ideal' )
 				);
 
-				echo  ' ';
+				echo ' ';
 
 				printf(
 					'<span class="rcp-help-tip dashicons dashicons-editor-help" title="%s"></span>',

--- a/views/edit-membership.php
+++ b/views/edit-membership.php
@@ -22,40 +22,11 @@
 			while ( $query->have_posts() ) {
 				$query->the_post();
 
-				echo '<div style="display: flex; gap: 1em; align-items: center;">';
-
 				printf(
 					'<a href="%s">%s</a>',
 					esc_url( get_edit_post_link() ),
 					esc_html( get_the_ID() )
 				);
-
-				echo ' ';
-
-				$action_url = wp_nonce_url(
-					add_query_arg(
-						[
-							'subscription_id' => get_the_ID(),
-							'action'          => 'pronamic_pay_rcp_update_subscription',
-						],
-					),
-					'pronamic_pay_rcp_update_subscription_' . get_the_ID()
-				);
-
-				printf(
-					'<a class="button" href="%s">%s</a>',
-					esc_url( $action_url ),
-					esc_html__( 'Update details to Pronamic Pay subscription', 'pronamic_ideal' )
-				);
-
-				echo ' ';
-
-				printf(
-					'<span class="rcp-help-tip dashicons dashicons-editor-help" title="%s"></span>',
-					esc_attr__( 'Updating ensures that date changes in the Restrict Content membership are updated in the Pronamic Pay subscription.', 'pronamic_ideal' )
-				);
-
-				echo '</div>';
 			}
 		}
 


### PR DESCRIPTION
This PR adds a "Update" button on the Restrict Content "Membership Details" page in the WordPress admin dashboard:

<img width="1025" alt="Scherm­afbeelding 2024-05-07 om 13 22 11" src="https://github.com/pronamic/wp-pronamic-pay-restrict-content-pro/assets/869674/c8d67708-6e8f-4603-876f-b80001455932">

This allows administrators to update the Restrict Content "Membership Details" to the Pronamic Pay subscription.
