### PR TITLE
Send "Renewal Payment Failed" email for failed recurring payment.

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -933,6 +933,7 @@ class Extension extends AbstractPluginIntegration {
 				'object_type'      => 'subscription',
 				'object_id'        => $rcp_membership->get_object_id(),
 				'status'           => PaymentStatus::from_core( $payment->get_status() ),
+				'gateway'          => $rcp_membership->get_gateway(),
 			]
 		);
 

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -403,15 +403,33 @@ class Extension extends AbstractPluginIntegration {
 					return;
 				}
 
+				if ( 'recurring' !== $payment->get_meta( 'mollie_sequence_type' ) ) {
+					return;
+				}
+
 				$last_pronamic_payment_id = \rcp_get_membership_meta( $rcp_membership->get_id(), '_pronamic_payment_id', true );
 
 				if ( '' != $last_pronamic_payment_id && $this_pronamic_payment_id != $last_pronamic_payment_id ) {
 					return;
 				}
 
-				$rcp_membership->expire();
+				$gateways = $this->get_gateways();
 
-				$rcp_membership->set_status( 'pending' );
+				$gateway_id = $rcp_membership->get_gateway();
+
+				if ( ! \array_key_exists( $gateway_id, $gateways ) ) {
+					return;
+				}
+
+				$gateway = $gateways[ $gateway_id ];
+
+				$rcp_gateway = new $gateway['class']();
+
+				$rcp_gateway->membership = $rcp_membership;
+
+				$member = new \RCP_Member( $payment->get_customer()->get_user_id() );
+
+				\do_action( 'rcp_recurring_payment_failed', $member, $rcp_gateway );
 
 				break;
 			case Core_PaymentStatus::SUCCESS:

--- a/src/Util.php
+++ b/src/Util.php
@@ -270,7 +270,7 @@ class Util {
 	 * @param Payment $payment           Pronamic payment object.
 	 * @return void
 	 */
-	public static function connect_pronamic_payment_id_to_rcp_payment( $rcp_membership_id, Payment $payment ) {
+	public static function connect_pronamic_payment_id_to_rcp_membership( $rcp_membership_id, Payment $payment ) {
 		\rcp_update_membership_meta( $rcp_membership_id, '_pronamic_payment_id', (string) $payment->get_id() );
 	}
 
@@ -283,7 +283,7 @@ class Util {
 	 * @param Payment $payment        Pronamic payment object.
 	 * @return void
 	 */
-	public static function connect_pronamic_payment_id_to_rcp_membership( $rcp_payment_id, Payment $payment ) {
+	public static function connect_pronamic_payment_id_to_rcp_payment( $rcp_payment_id, Payment $payment ) {
 		\rcp_update_payment_meta( $rcp_payment_id, '_pronamic_payment_id', (string) $payment->get_id() );
 	}
 }


### PR DESCRIPTION
Fix #10.

During development, I noticed payments were not connected correctly. This was caused by mixed `Util::connect_pronamic_payment_id_to_rcp_*()` method names. This PR renames these methods, which resolves the incorrect RCP payment/membership IDs they were receiving before.