### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
 		"automattic/jetpack-autoloader": "^3.0 || ^4.0 || ^5.0",
 		"pronamic/wp-money": "^2.4",
 		"pronamic/wp-number": "^1.4",
-		"woocommerce/action-scheduler": "^3.9",
+		"woocommerce/action-scheduler": "^3.9 || ^4.0",
 		"wp-pay-gateways/mollie": "^4.15",
 		"wp-pay/core": "^4.28"
 	},


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.